### PR TITLE
Disable wiki support in Eclipse TM4E project

### DIFF
--- a/otterdog/eclipse-tm4e.jsonnet
+++ b/otterdog/eclipse-tm4e.jsonnet
@@ -30,7 +30,7 @@ orgs.newOrg('technology.tm4e', 'eclipse-tm4e') {
       description: "TextMate support in Eclipse IDE",
       has_discussions: true,
       has_projects: false,
-      has_wiki: true,
+      has_wiki: false,
       homepage: "https://projects.eclipse.org/projects/technology.tm4e",
       squash_merge_commit_message: "PR_BODY",
       squash_merge_commit_title: "PR_TITLE",


### PR DESCRIPTION
We migrated the documentation into the repo's docs/ folder